### PR TITLE
Nuevo dominio de la wiki

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,8 @@
 ---
 # Jekyll options.
 name: uqbar-wiki
-domain: uqbar-project.github.io
-baseurl: /wiki
+domain: wiki.uqbar.org
+baseurl: /
 description: "Wiki jekyll engine for Uqbar organization"
 markdown: kramdown
 highlighter: rouge


### PR DESCRIPTION
El baseurl estaba rompiendo todos los links.

La wiki en Github:Pages estaba en uqbar.github.io/wiki (uqbar.github.io es el dominio, /wiki la baseUrl), entonces todos los links a assets se generan con `/wiki/` adelante. Ahora está en la raíz de wiki.uqbar.org, entonces hay que volarle el `/wiki` del baseUrl.

No lo testeé, pero debería andar, estimo (hasta quizá se pueda borrar la property `baseUrl` directamente)