### PR TITLE
CNAME + baseUrl correspondiente

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,2 @@
+wiki.uqbar.org
+

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,6 @@
 # Jekyll options.
 name: uqbar-wiki
 domain: wiki.uqbar.org
-baseurl: /
 description: "Wiki jekyll engine for Uqbar organization"
 markdown: kramdown
 highlighter: rouge


### PR DESCRIPTION
El CNAME no estaba en `master`, y por eso se perdió al deployar después del merge de #2