### PR TITLE
Fix page formatting

### DIFF
--- a/wiki/articles/precedencia-de-los-operadores-mas-comunes-en-haskell.md
+++ b/wiki/articles/precedencia-de-los-operadores-mas-comunes-en-haskell.md
@@ -6,7 +6,7 @@ title: Precedencia de los operadores mas comunes en haskell
 Definición en el Prelude
 ------------------------
 
-La siguiente tabla muestra la precedencia de los operadores que más utilizamos en Haskell. A mayor número mayor precedencia. Por ejemplo, el operador tiene mayor precedencia que por lo tanto si escribimos:
+La siguiente tabla muestra la precedencia de los operadores que más utilizamos en Haskell. A mayor número mayor precedencia. Por ejemplo, el operador `+` tiene mayor precedencia que `<`, por lo tanto si escribimos:
 
 `3 < 4 + 5`
 
@@ -16,51 +16,69 @@ se entiende como:
 
 La tabla (simplificada) es la siguiente:
 
-`infixr 9  .`
-`infixl 9  !!`
-`infixr 8  ^, ^^, **`
-`` infixl 7  *, /, `quot`, `rem`, `div`, `mod`, :%, % ``
-`infixl 6  +, -`
-`infixr 5  :`
-`infixr 5  ++`
-`` infix  4  ==, /=, <, <=, >=, >, `elem`, `notElem` ``
-`infixr 3  &&`
-`infixr 2  ||`
-`infixr 0 $`
+```
+infixr 9  .
+infixl 9  !!
+infixr 8  ^, ^^, **
+infixl 7  *, /, `quot`, `rem`, `div`, `mod`, :, %
+infixl 6  +, -
+infixr 5  :
+infixr 5  ++
+infix  4  ==, /=, <, <=, >=, >, `elem`, `notElem`
+infixr 3  &&
+infixr 2  ||
+infixr 0 $
+```
 
 Bonus: Asociatividad
 --------------------
 
-Las palabras clave , e permiten indicar la *asociatividad* del operador. Los operadores definidos con asocian a izquierda, mientras que los asocian a derecha. Por lo tanto, la expresión:
+Las palabras clave `infixl` e `infixr` permiten indicar la *asociatividad* del operador. Los operadores definidos con `infixl` asocian a izquierda, mientras que los `infixr` asocian a derecha. Por lo tanto, la expresión:
 
-`3 + 4 + 5`
+```
+3 + 4 + 5
+```
 
-se evalúa como
+Se evalúa como:
 
-`(3 + 4) + 5`
+```
+(3 + 4) + 5
+```
 
-ya que el operador asocia a izquierda. En cambio la expresión
+Ya que el operador asocia a izquierda. En cambio la expresión:
 
-`2:3:4:[]`
+```
+2:3:4:[]
+```
 
-se debe leer como
+Se debe leer como:
 
-`2:(3:(4:[]))`
+```
+2:(3:(4:[]))
+```
 
-ya que el operador asocia a derecha, al igual que la composición (), por ejemplo
+Ya que el operador asocia a derecha, al igual que la composición (`.`), por ejemplo:
 
-`snd . head . filter even`
+```
+snd . head . filter even
+```
 
-debe leerse como
+Debe leerse como:
 
-`snd . (head . filter even).`
+```
+snd . (head . filter even).
+```
 
-También puede notarse que todos los operadores tienen menor precedencia que la aplicación funcional, es decir que al ejemplo anterior podríamos definirlo completamente si agregamos los paréntesis alrededor de .
+También puede notarse que todos los operadores tienen menor precedencia que la aplicación funcional, es decir que al ejemplo anterior podríamos definirlo completamente si agregamos los paréntesis alrededor de `.`:
 
-`snd . (head . (filter even)).`
+```
+snd . (head . (filter even)).
+```
 
-Los operadores definidos como no son asociativos, por ejemplo el operador de igualdad . Por lo tanto la expresión:
+Los operadores definidos como `infix` no son asociativos, por ejemplo el operador de igualdad `==`. Por lo tanto la expresión:
 
-`a == b == c`
+```
+a == b == c
+```
 
-no se entiende como ni como ; la expresión sin paréntesis es incorrecta.
+No se entiende como `(a == b) == c` ni como `a == (b == c)`; la expresión sin paréntesis es incorrecta.

--- a/wiki/articles/precedencia-de-los-operadores-mas-comunes-en-haskell.md
+++ b/wiki/articles/precedencia-de-los-operadores-mas-comunes-en-haskell.md
@@ -27,7 +27,7 @@ infixr 5  ++
 infix  4  ==, /=, <, <=, >=, >, `elem`, `notElem`
 infixr 3  &&
 infixr 2  ||
-infixr 0 $
+infixr 0  $
 ```
 
 Bonus: Asociatividad

--- a/wiki/articles/precedencia-de-los-operadores-mas-comunes-en-haskell.md
+++ b/wiki/articles/precedencia-de-los-operadores-mas-comunes-en-haskell.md
@@ -66,7 +66,7 @@ snd . head . filter even
 Debe leerse como:
 
 ```
-snd . (head . filter even).
+snd . (head . filter even)
 ```
 
 También puede notarse que todos los operadores tienen menor precedencia que la aplicación funcional, es decir que al ejemplo anterior podríamos definirlo completamente si agregamos los paréntesis alrededor de `.`:

--- a/wiki/articles/precedencia-de-los-operadores-mas-comunes-en-haskell.md
+++ b/wiki/articles/precedencia-de-los-operadores-mas-comunes-en-haskell.md
@@ -72,7 +72,7 @@ snd . (head . filter even).
 También puede notarse que todos los operadores tienen menor precedencia que la aplicación funcional, es decir que al ejemplo anterior podríamos definirlo completamente si agregamos los paréntesis alrededor de `.`:
 
 ```
-snd . (head . (filter even)).
+snd . (head . (filter even))
 ```
 
 Los operadores definidos como `infix` no son asociativos, por ejemplo el operador de igualdad `==`. Por lo tanto la expresión:


### PR DESCRIPTION
It seems the initial import from the MediaWiki had issues with the code tags or the extensive use of punctuation in the page, so the current version is missing really important info.

I've tried my best to understand from the context what the missing gaps should have said, but I'm not 100% sure - so **please** check the info is accurate.